### PR TITLE
[RFR] Feature/auto resolve commits range

### DIFF
--- a/doc/arch/adr-001-expectations.md
+++ b/doc/arch/adr-001-expectations.md
@@ -49,15 +49,9 @@ $ ssc \
                                 # continue the build for this app when changes
                                 # on multiple apps should be considered (i.e.
                                 # for integration purposes).
-    --pr-url <url> \            # Optional, the URL of a PR to use to fetch a
-                                # range of commits.
-    --auth <auth> \             # The credentials to use to fetch a range of
-                                # commits on the given pr-url.
-    --from <from_commit_hash> \ # Defaults to HEAD~1, overriden by the first
-                                # PR commit when the --pr-url flag is provided
-                                # and not empty, and the PR commits could be
-                                # fetched.
-    --to <to_commit_hash> \     # Defaults to HEAD.
+    --base-branch <branch_name> # Defaults to `origin/master`. The branch to
+                                # use as a base to know from where the commit
+                                # range starts (i.e. to find the merge base).
     --cmd "<skip_job_cmd>"      # The command to use to skip the build.
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,17 +9,8 @@ struct RawCli {
     #[structopt(long = "path", help = "The path to inspect. Defaults to cwd. This arg can be specified multiple times to inspect multiple paths.")]
     paths: Vec<PathBuf>,
 
-    #[structopt(long = "pr-url", default_value = "", help = "The app name for which this CI job is for.")]
-    pr_url: String,
-
-    #[structopt(long = "auth", default_value = "", help = "The credentials to use to connect to the PR URL.")]
-    auth: String,
-
-    #[structopt(long = "from", default_value = "HEAD~1", help = "From commit hash. Defaults to HEAD~1 overriden by the first PR commit when the --pr-url flag is provided.")]
-    from: String,
-
-    #[structopt(long = "to", default_value = "HEAD", help = "The end commit hash. Defaults to HEAD.")]
-    to: String,
+    #[structopt(long = "base-branch", default_value = "origin/master", help = "The branch to use as a base to know from where the commit range starts (i.e. to find the merge base).")]
+    base_branch: String,
 
     #[structopt(long = "cmd", help = "The command to use to skip the build.")]
     cmd: String,
@@ -52,20 +43,8 @@ impl Cli {
         return &self.paths;
     }
 
-    pub fn pr_url(&self) -> &String {
-        return &self.raw_cli.pr_url;
-    }
-
-    pub fn auth(&self) -> &String {
-        return &self.raw_cli.auth;
-    }
-
-    pub fn from(&self) -> &String {
-        return &self.raw_cli.from;
-    }
-
-    pub fn to(&self) -> &String {
-        return &self.raw_cli.to;
+    pub fn base_branch(&self) -> &String {
+        return &self.raw_cli.base_branch;
     }
 
     pub fn cmd(&self) -> &String {

--- a/src/git/asserter.rs
+++ b/src/git/asserter.rs
@@ -1,0 +1,14 @@
+use std::process::Output;
+
+pub fn assert_or_panic(result: &Output, name: &String) {
+    if result.status.success() {
+        return;
+    }
+
+    panic!(format!(
+        "error: {} command exited with status code {}. Reason: {}",
+        name,
+        result.status.code().unwrap(),
+        String::from_utf8(result.stderr.clone()).unwrap(),
+    ));
+}

--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -1,0 +1,34 @@
+use std::process::Command;
+use crate::git::asserter::assert_or_panic;
+
+pub fn get_current_branch() -> String {
+    let result = Command::new("git")
+        .arg("rev-parse")
+        .arg("--abbrev-ref")
+        .arg("HEAD")
+        .output()
+        .expect("Failed to determine current branch.")
+    ;
+
+    assert_or_panic(&result, &String::from("get branch"));
+
+    let output: String = String::from_utf8(result.stdout).unwrap();
+
+    return String::from(output.trim());
+}
+
+pub fn get_merge_base_commit(base_branch: &String) -> String {
+    let result = Command::new("git")
+        .arg("merge-base")
+        .arg(base_branch)
+        .arg("HEAD")
+        .output()
+        .expect("Failed to determine merge base.")
+    ;
+
+    assert_or_panic(&result, &String::from("git merge-base"));
+
+    let output: String = String::from_utf8(result.stdout).unwrap();
+
+    return String::from(output.trim());
+}

--- a/src/git/commits_range.rs
+++ b/src/git/commits_range.rs
@@ -1,4 +1,6 @@
 use crate::cli::Cli;
+use crate::git::branch::get_current_branch;
+use crate::git::branch::get_merge_base_commit;
 
 pub struct CommitsRange {
     from: String,
@@ -16,9 +18,23 @@ impl CommitsRange {
 }
 
 pub fn resolve_commits_range(cli: &Cli) -> CommitsRange {
-    // @TODO consider the --pr-url flag to determine the commits range
     return CommitsRange{
-        from: String::from(cli.from()),
-        to: String::from(cli.to()),
+        from: resolve_range_start_commit(cli.base_branch()),
+        to: String::from("HEAD"),
     }
+}
+
+fn resolve_range_start_commit(base_branch: &String) -> String {
+    let current_branch: String = get_current_branch();
+
+    if current_branch == base_branch.to_owned() {
+        // When we're on the base branch, use HEAD~1 as the range start commit
+        // as it should be a merge commit.
+        return String::from("HEAD~1");
+    }
+
+    // When we're not on the base branch, we determine the range start commit
+    // from the point when the current branch has been issued from the base
+    // branch.
+    return get_merge_base_commit(base_branch);
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,2 +1,5 @@
 pub mod commits_range;
 pub mod path_inspector;
+
+mod branch;
+mod asserter;

--- a/src/git/path_inspector.rs
+++ b/src/git/path_inspector.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::process::Command;
 use crate::git::commits_range::CommitsRange;
+use crate::git::asserter::assert_or_panic;
 
 pub fn has_changes_in_paths(
     commits_range: &CommitsRange,
@@ -14,13 +15,7 @@ pub fn has_changes_in_paths(
         .expect("Failed to run git log command.")
     ;
 
-    if !result.status.success() {
-        panic!(format!(
-            "error: git log command exited with status code {}. Reason: {}",
-            result.status.code().unwrap(),
-            String::from_utf8(result.stderr).unwrap(),
-        ));
-    }
+    assert_or_panic(&result, &String::from("git log"));
 
     return !result.stdout.is_empty();
 }


### PR DESCRIPTION
Do not rely on an HTTP API to identify the `from` commit as the CI build
is launched before the PR is created. So we can't know what are the
commits of the PR.

Instead, we rely on `git merge-base` to find the best ancestor for a
merge (i.e. the `from` commit of the range of commits of the PR).

## TODO

- [x] squash commits when approved