### PR TITLE
[RFR] differentiate remote and base branch parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cargo/
+git/Cargo.lock
 target/

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -9,7 +9,10 @@ struct RawCli {
     #[structopt(long = "path", help = "The path to inspect. Defaults to cwd. This arg can be specified multiple times to inspect multiple paths.")]
     paths: Vec<PathBuf>,
 
-    #[structopt(long = "base-branch", default_value = "origin/master", help = "The branch to use as a base to know from where the commit range starts (i.e. to find the merge base).")]
+    #[structopt(long = "remote", default_value = "origin", help = "The name of the tracked repository.")]
+    remote: String,
+
+    #[structopt(long = "base-branch", default_value = "master", help = "The branch to use as a base to know from where the commit range starts (i.e. to find the merge base).")]
     base_branch: String,
 
     #[structopt(long = "cmd", help = "The command to use to skip the build.")]
@@ -41,6 +44,10 @@ impl Cli {
 
     pub fn paths(&self) -> &Vec<PathBuf> {
         return &self.paths;
+    }
+
+    pub fn remote(&self) -> &String {
+        return &self.raw_cli.remote;
     }
 
     pub fn base_branch(&self) -> &String {

--- a/doc/arch/adr-001-expectations.md
+++ b/doc/arch/adr-001-expectations.md
@@ -49,9 +49,11 @@ $ ssc \
                                 # continue the build for this app when changes
                                 # on multiple apps should be considered (i.e.
                                 # for integration purposes).
-    --base-branch <branch_name> # Defaults to `origin/master`. The branch to
-                                # use as a base to know from where the commit
-                                # range starts (i.e. to find the merge base).
+    --remote <remote_name>      # Defaults to `origin`. The name of the tracked
+                                # repository.
+    --base-branch <branch_name> # Defaults to `master`. The branch to use as
+                                # a base to know from where the commit range
+                                # starts (i.e. to find the merge base).
     --cmd "<skip_job_cmd>"      # The command to use to skip the build.
 ```
 

--- a/git/src/branch.rs
+++ b/git/src/branch.rs
@@ -18,10 +18,32 @@ pub fn get_current_branch() -> String {
     return String::from(output.trim());
 }
 
-pub fn get_merge_base_commit(base_branch: &String) -> String {
+pub fn get_current_remote() -> String {
+    let result = Command::new("git")
+        .arg("remote")
+        .arg("show")
+        .output()
+        .expect("Failed to determine current remote.")
+    ;
+
+    assert_or_panic(&result, &String::from("get remote"));
+
+    let output: String = String::from_utf8(result.stdout).unwrap();
+
+    return String::from(output.trim());
+}
+
+pub fn get_merge_base_commit(
+    remote: &String,
+    base_branch: &String,
+) -> String {
     let result = Command::new("git")
         .arg("merge-base")
-        .arg(base_branch)
+        .arg(format!(
+            "{}/{}",
+            remote,
+            base_branch,
+        ))
         .arg("HEAD")
         .output()
         .expect("Failed to determine merge base.")

--- a/git/src/commits_range.rs
+++ b/git/src/commits_range.rs
@@ -1,4 +1,5 @@
 use crate::branch::get_current_branch;
+use crate::branch::get_current_remote;
 use crate::branch::get_merge_base_commit;
 
 pub struct CommitsRange {
@@ -16,24 +17,39 @@ impl CommitsRange {
     }
 }
 
-pub fn resolve_commits_range(base_branch: &String) -> CommitsRange {
+pub fn resolve_commits_range(
+    remote: &String,
+    base_branch: &String,
+) -> CommitsRange {
     return CommitsRange{
-        from: resolve_range_start_commit(base_branch),
+        from: resolve_range_start_commit(
+            remote,
+            base_branch,
+        ),
         to: String::from("HEAD"),
     }
 }
 
-fn resolve_range_start_commit(base_branch: &String) -> String {
+fn resolve_range_start_commit(
+    remote: &String,
+    base_branch: &String,
+) -> String {
+    let current_remote: String = get_current_remote();
     let current_branch: String = get_current_branch();
 
-    if current_branch == base_branch.to_owned() {
-        // When we're on the base branch, use HEAD~1 as the range start commit
-        // as it should be a merge commit.
+    if current_remote == remote.to_owned()
+      && current_branch == base_branch.to_owned()
+    {
+        // When we've checked out the remote base branch, use HEAD~1
+        // as the range start commit as it should be a merge commit.
         return String::from("HEAD~1");
     }
 
     // When we're not on the base branch, we determine the range start commit
     // from the point when the current branch has been issued from the base
     // branch.
-    return get_merge_base_commit(base_branch);
+    return get_merge_base_commit(
+        remote,
+        base_branch,
+    );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,10 @@ use ci::run_stop_cmd;
 fn main() {
     let cli: Cli = Cli::new();
 
-    let commits_range: CommitsRange = resolve_commits_range(cli.base_branch());
+    let commits_range: CommitsRange = resolve_commits_range(
+        cli.remote(),
+        cli.base_branch(),
+    );
 
     if has_changes_in_paths(&commits_range, cli.paths()) {
         println!("Changes detected. The CI build should continue.");


### PR DESCRIPTION
Differentiate the remote (defaults to `origin`) and base_branch
(defaults to `master`) parameters in order to identify whether we're on
the `origin/master` branch (i.e. when a merge is done on master) or when
we're on `origin/feature-branch` (i.e. when a commit is pushed on a
feature branch).

Mixing the remote and the branch in the `base-branch` parameter
(e.g. `origin/master`) wasn't precise enough to check when we've
checked out the default base branch from the default remote, as we were
only considering the current branch name and not the current remote name
during comparison.