### PR TITLE
fix cargo warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ documentation = "https://github.com/KnpLabs/should-skip-ci"
 authors = ["KNP Labs"]
 readme = "README.md"
 license = "MIT"
-license-file = "LICENSE"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
```
$ cargo build
warning: only one of `license` or `license-file` is necessary
`license` should be used if the package license can be expressed with a standard SPDX expression.
`license-file` should be used if the package uses a non-standard license.
```