### PR TITLE
fix automatic assets upload when a release is published

### DIFF
--- a/.circleci/upload_release_asset.sh
+++ b/.circleci/upload_release_asset.sh
@@ -11,7 +11,7 @@ printerr() {
 
 get_assets_url() {
     url="$(curl -s \
-        -u "knpEdgar:${GH_ACCESS_TOKEN}" \
+        -u "knpEdgarSsc:${GH_ACCESS_TOKEN}" \
         "https://api.github.com/repos/KnpLabs/should-skip-ci/releases/tags/${GIT_TAG}" \
     | jq -r .assets_url)"
 
@@ -22,7 +22,7 @@ upload_bin() {
     local assets_url="${1}"
 
     curl -s \
-        -u "knpEdgar:${GH_ACCESS_TOKEN}" \
+        -u "knpEdgarSsc:${GH_ACCESS_TOKEN}" \
         -H "Content-Type: application/octet-stream" \
         --data-binary "@${SSC_BIN}" \
         "${assets_url}?name=ssc-x86_64"


### PR DESCRIPTION
The previous token was out of date. I created a new machine user on
github with access to this repo only, and generated a new access token.
I updated circleci env vars with this token.
I manually ran the `upload_release_asset.sh` script on circleci to test
these settings and to upload the assets of v0.2.1 release (which has
previously failed due to previous credentials invalidity).