### PR TITLE
[RFR] indicate that any git node is a valid `path` arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ OPTIONS:
                                    find the merge base). [default: master]
     --cmd <cmd>                    The command to use to skip the build.
     --path <paths>...              The path to inspect. Defaults to cwd. This arg can be specified multiple times to
-                                   inspect multiple paths.
+                                   inspect multiple paths. A path should point to any git node in the source tree.
     --remote <remote>              The name of the tracked repository. [default: origin]
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ use structopt::StructOpt;
 #[derive(StructOpt)]
 #[structopt(name = "ssc", about = "should-skip-ci")]
 struct RawCli {
-    #[structopt(long = "path", help = "The path to inspect. Defaults to cwd. This arg can be specified multiple times to inspect multiple paths.")]
+    #[structopt(long = "path", help = "The path to inspect. Defaults to cwd. This arg can be specified multiple times to inspect multiple paths. A path should point to any git node in the source tree.")]
     paths: Vec<PathBuf>,
 
     #[structopt(long = "remote", default_value = "origin", help = "The name of the tracked repository.")]


### PR DESCRIPTION
To make it clearer how to use the tool.