### PR TITLE
[RFR] fix ssc default behavior : must use base branch comparison when no optional args are provided

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,6 @@
 use std::env::current_dir;
 use std::path::PathBuf;
 use clap::Parser;
-use clap::builder::NonEmptyStringValueParser;
 use clap::ArgAction::Count;
 
 // RawCli represents the CLI args and options as passed on a shell.
@@ -33,7 +32,6 @@ struct RawCli {
         visible_alias = "base-tag",
         conflicts_with = "base_branch",
         default_value = "",
-        value_parser = NonEmptyStringValueParser::new(),
         long_help = "The ref (i.e. commit or tag) from where to look for changes. Not usable with `base-branch` arg.",
     )]
     base_ref: String,

--- a/src/git/commits_range.rs
+++ b/src/git/commits_range.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use super::branch::get_current_branch;
 use super::branch::get_current_remote;
 use super::branch::get_merge_base_commit;
+use log::debug;
 
 pub struct CommitsRange {
     from: String,
@@ -42,15 +43,24 @@ fn resolve_start_ref(
     base_branch: &String,
     base_ref: &String,
 ) -> String {
+    let start_ref: String;
+
     if !base_ref.is_empty() {
-        return base_ref.to_string();
+        start_ref = base_ref.to_string();
+        debug!("CommitsRange : Using base ref as start ref ({}).", &start_ref);
+
+        return start_ref;
     }
 
-    return resolve_base_branch_start_ref(
+    start_ref = resolve_base_branch_start_ref(
         &working_directory,
         remote,
         base_branch,
     );
+
+    debug!("CommitsRange : Using base branch as start ref ({}).", &start_ref);
+
+    return start_ref;
 }
 
 fn resolve_base_branch_start_ref(


### PR DESCRIPTION
PR [40](https://github.com/KnpLabs/should-skip-ci/pull/40) has introduced a change in the default behavior of ssc. When running the tool as usual, there was an error raised :

```
$ ssc --path <path> --cmd <stop_command>

error: a value is required for '--base-ref <BASE_REF>' but none was supplied
```

whereas it should use the base branch comparison by default (as we don't want people who are upgrading ssc to change their CI scripts).

This commit fixes this issue.